### PR TITLE
Added aszdziennik.pl

### DIFF
--- a/hosts.json
+++ b/hosts.json
@@ -53,6 +53,9 @@
         },
         {
             "host": "denverguardian.com"
+        },
+        {
+            "host": "aszdziennik.pl"
         }
     ]
 }

--- a/hosts.json
+++ b/hosts.json
@@ -53,7 +53,9 @@
         },
         {
             "host": "denverguardian.com"
-        },
+        }
+    ],
+    "satire": [
         {
             "host": "aszdziennik.pl"
         }

--- a/hosts/aszdziennik.pl.json
+++ b/hosts/aszdziennik.pl.json
@@ -1,0 +1,4 @@
+{
+    "title": "Aszdziennik",
+    "reason": "This site is known for posting fake information."
+}

--- a/hosts/aszdziennik.pl.json
+++ b/hosts/aszdziennik.pl.json
@@ -1,4 +1,4 @@
 {
     "title": "Aszdziennik",
-    "reason": "This site is known for posting fake information."
+    "reason": "This site is known for posting satire."
 }


### PR DESCRIPTION
Aszdziennik is a polish site which goal is to write fake news/articles. They annotate every news with "To jest ASZdziennik. Wszelkie wydarzenia i cytaty zostały zmyślone." which translates to "It is ASZdziennik. All events and quotes are made up."